### PR TITLE
security: harden detection — 9-3900-3 IoC variant + 1000-char line gate

### DIFF
--- a/.github/workflows/security-precommit.yml
+++ b/.github/workflows/security-precommit.yml
@@ -86,6 +86,40 @@ esac
           fi
           echo "IoC scan passed."
 
+      - name: Reject single lines > 1000 chars (Shai-Hulud minified-payload signal)
+        # Shai-Hulud-family payloads are always a single minified line >5000 chars.
+        # Legitimate source rarely exceeds 200. High-precision, near-zero-FP signal.
+        # Driven by: rival-review consensus (Gemini-3.1-pro, GPT-5.4) — see 2026-05-13.
+        run: |
+          set -uo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          BAD_LINE=$(git diff "$BASE_SHA" "$HEAD_SHA" -- \
+              ':!*.lock' ':!**/package-lock.json' ':!**/yarn.lock' \
+              ':!**/pnpm-lock.yaml' ':!**/composer.lock' \
+              ':!.gitleaks.toml' \
+              ':!**/*.min.js' ':!**/*.min.css' ':!**/*.map' \
+              ':!**/dist/**' ':!**/build/**' ':!**/node_modules/**' \
+              ':!.github/workflows/security-*.yml' \
+              ':!docs/incident-*' ':!SECURITY-*.md' ':!MALWARE-*.md' \
+            | awk '/^\+[^+]/ {
+                line = substr($0, 2);
+                if (length(line) > 1000) {
+                  print length(line);
+                  exit
+                }
+              }')
+
+          if [ -n "$BAD_LINE" ]; then
+            echo "::error::A single added line exceeds 1000 characters ($BAD_LINE chars)."
+            echo "Shai-Hulud-family malware payloads are always a single minified line >5000 chars."
+            echo "If this is a legitimate long line (e.g. a generated config), exempt the file"
+            echo "in the workflow's git-diff pathspec list (':!path/to/file')."
+            exit 1
+          fi
+          echo "✅ All added lines under 1000 chars."
+
       - name: Suspicious-timezone fingerprint check
         run: |
           set -uo pipefail

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -84,7 +84,7 @@ tags = ["secret", "gcp"]
 [[rules]]
 id = "bb-malware-blockchain-loader-marker"
 description = "Marker strings from the 2026-04-30 blockchain-loader malware — block any PR that re-introduces them"
-regex = '''(?:_\$_1e42|sfL\(.wuqkt|api\.trongrid\.io|fullnode\.mainnet\.aptoslabs\.com|Tgw\(2509\)|global\["_V"\]\s*=\s*['"]A?9-3900)'''
+regex = '''(?:_\$_1e42|sfL\(.wuqkt|api\.trongrid\.io|fullnode\.mainnet\.aptoslabs\.com|Tgw\(2509\)|global\[['\"][^'\"]+['\"]\]\s*=\s*['\"][A-Z]?9-\d{4}(?:-\d+)?)'''
 keywords = ["_$_1e42", "trongrid", "aptoslabs", "Tgw(2509)"]
 tags = ["malware", "incident-2026-04-30"]
 


### PR DESCRIPTION
## Summary

Step 4 Bundle 1 — detection-hardening. Two changes, both auto-pass the gates landed in Step 3 yesterday.

### 1. `.gitleaks.toml` — broaden the `bb-malware-blockchain-loader-marker` regex

The 2026-05-09 wave-3 reinfection (precheckin-backend `logger.js`, tenant_api `ecosystem.config.example.js`) used `global['!']='9-3900-3'` — different bracket key than wave 1/2 (`'_V'`) and a `-N` campaign-suffix the old rule did not match. The rule fired on wave 3 anyway via the other alternatives (`_$_1e42`, `Tgw(2509)`, etc.) but the campaign-tag arm was effectively dead.

New regex accepts any bracket key and any `-<digit>` suffix:

```
global\[['"][^'"]+['"]\]\s*=\s*['"][A-Z]?9-\d{4}(?:-\d+)?
```

### 2. `.github/workflows/security-precommit.yml` — 1000-char single-line gate

New `scan-pr` step that rejects any single added line >1000 chars. Shai-Hulud payloads are always one minified line >5000 chars; legitimate source rarely exceeds 200. Pathspec exempts lockfiles, minified bundles, dist/build dirs, detection-rule files, and incident docs.

Driven by: rival-review consensus from Gemini-3.1-pro + GPT-5.4 on the 2026-05-13 secret-architecture review.

## Test plan

- [ ] CI: Gitleaks pass, scan-pr pass, Review new dependencies pass
- [ ] Confirm rule still catches a synthetic wave-1/wave-2/wave-3 IoC line
- [ ] Confirm a synthetic 5000-char single line in a non-exempt file is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
