### PR TITLE
security(ci): add PR-shape tag for adds-file + modifies-config combo

### DIFF
--- a/.github/workflows/security-pr-shape.yml
+++ b/.github/workflows/security-pr-shape.yml
@@ -1,0 +1,137 @@
+name: PR Shape Tag
+
+# Auto-labels any PR that matches the "wave-3 attack shape": adds at least one
+# new file AND modifies at least one IoC-vulnerable config file in the same PR.
+# This is the exact pattern of the 2026-05-09 reinfection PRs (precheckin-backend
+# #24, tenant_api #9): a benign-looking new file (`secret-manager-loader.js`)
+# arrives alongside a payload-bearing edit to an existing config file (`logger.js`
+# / `ecosystem.config.example.js`).
+#
+# Tag is informational — it does NOT block merge — but it forces a reviewer to
+# look at the diff with the right mental model. Pair with mandatory CODEOWNERS
+# review on config-file edits if that's not enabled yet.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write   # add labels + comment
+
+jobs:
+  shape-check:
+    name: shape-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout (PR head, shallow)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect adds-file + modifies-config combo
+        id: shape
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+
+          # Files newly added in this PR (A = added)
+          ADDED=$(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA" || true)
+
+          # Existing config files modified in this PR (M = modified)
+          MODIFIED=$(git diff --name-only --diff-filter=M "$BASE_SHA" "$HEAD_SHA" || true)
+
+          # IoC-vulnerable filenames (the ones Shai-Hulud has historically poisoned)
+          IOC_VULN_RE='(^|/)(logger|tailwind|vite|webpack|next|babel|ecosystem|metro|nuxt|rollup|esbuild)\.config(\.example)?\.(js|ts|cjs|mjs)$|(^|/)(logger|index)\.(js|ts)$'
+
+          MOD_VULN=$(printf '%s\n' "$MODIFIED" | grep -E "$IOC_VULN_RE" || true)
+          ADDED_COUNT=$(printf '%s\n' "$ADDED" | grep -c '.' || true)
+          MOD_VULN_COUNT=$(printf '%s\n' "$MOD_VULN" | grep -c '.' || true)
+
+          if [ "$ADDED_COUNT" -ge 1 ] && [ "$MOD_VULN_COUNT" -ge 1 ]; then
+            echo "match=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "added_files<<EOF"
+              echo "$ADDED"
+              echo "EOF"
+              echo "modified_vuln_files<<EOF"
+              echo "$MOD_VULN"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "::warning::PR matches the 2026-05-09 reinfection shape (adds-file + modifies-IoC-config)."
+          else
+            echo "match=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply needs-extra-scrutiny label + comment
+        if: steps.shape.outputs.match == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const repo = context.repo;
+            const prNum = context.issue.number;
+            const label = 'needs-extra-scrutiny';
+
+            // Ensure label exists (create if missing — idempotent)
+            try {
+              await github.rest.issues.getLabel({ owner: repo.owner, repo: repo.repo, name: label });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: repo.owner, repo: repo.repo,
+                  name: label, color: 'd93f0b',
+                  description: 'PR shape matches a known supply-chain attack pattern; verify diff carefully',
+                });
+              } else { throw e; }
+            }
+
+            // Add label to PR
+            await github.rest.issues.addLabels({
+              owner: repo.owner, repo: repo.repo,
+              issue_number: prNum,
+              labels: [label],
+            });
+
+            // Post a one-time comment (skip if a matching comment already exists)
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: repo.owner, repo: repo.repo,
+              issue_number: prNum,
+            });
+            const MARKER = '<!-- pr-shape-tag:wave3 -->';
+            if (!comments.some(c => c.body && c.body.includes(MARKER))) {
+              const added = `${{ steps.shape.outputs.added_files }}`;
+              const modVuln = `${{ steps.shape.outputs.modified_vuln_files }}`;
+              const body = [
+                MARKER,
+                '## ⚠️ This PR matches the 2026-05-09 reinfection shape',
+                '',
+                'This PR **adds at least one new file** *and* **modifies at least one IoC-vulnerable config file** in the same diff. That is the exact pattern of the wave-3 Shai-Hulud reinfection PRs (`precheckin-backend#24`, `tenant_api#9`), where a benign-looking new file arrived alongside a payload-bearing edit to an existing config file.',
+                '',
+                '**This tag is informational and does not block merge.** It exists so a reviewer looks at the diff with the right mental model — pay extra attention to:',
+                '',
+                '- Any single line >1000 chars in the modified config file (Shai-Hulud payloads are always one minified line)',
+                '- Content appended *after* the closing `};` of `module.exports = { ... };`',
+                '- Calls into `require()`, `eval()`, `Function()`, or blockchain RPCs (`bsc-dataseed`, `trongrid`, `aptoslabs`) from the modified config file',
+                '',
+                '**Added files:**',
+                '```',
+                added.trim(),
+                '```',
+                '',
+                '**Modified IoC-vulnerable config files:**',
+                '```',
+                modVuln.trim(),
+                '```',
+                '',
+                'If the diff looks clean after that check, dismiss this comment and approve normally.',
+              ].join('\n');
+              await github.rest.issues.createComment({
+                owner: repo.owner, repo: repo.repo,
+                issue_number: prNum,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

Step 4 Bundle 2 — adds a new `PR Shape Tag` workflow that auto-labels any PR matching the 2026-05-09 reinfection shape: **adds ≥1 new file** AND **modifies ≥1 IoC-vulnerable config file** (logger.js, ecosystem*.js, tailwind/vite/webpack/babel/next.config.js, etc.) in the same diff.

This was the exact pattern of `precheckin-backend#24` and `tenant_api#9` — a benign-looking new file (`secret-manager-loader.js`) arrived alongside a payload-bearing edit to an existing config file (`logger.js` / `ecosystem.config.example.js`). The wave-3 IoC slipped past every existing gate because reviewers' attention was on the new file, not the modified one.

## What this workflow does

- Triggers on every PR open/synchronize/reopen
- Diffs base..head, counts added files (A) and modified IoC-vulnerable files (M)
- If both ≥1: applies `needs-extra-scrutiny` label (creates the label if missing) + posts a one-time comment explaining the pattern and pointing reviewers at the exact things to check (>1000-char lines, content after `module.exports = { };`, calls into `require()`/`eval()`/blockchain RPCs)

**The tag is informational — it does NOT block merge.** It changes the mental model of the reviewer.

Driven by: 2026-05-11 security audit §"HIGH — Detection-evasion attack pattern: payload-via-security-PR".

## Test plan

- [ ] CI: Gitleaks pass, scan-pr pass, Review new dependencies pass
- [ ] Trigger the workflow on a synthetic test PR that adds `test-new.js` and modifies `tailwind.config.js` — expect `needs-extra-scrutiny` label + comment
- [ ] Trigger on a clean PR (only modifies one file, no adds) — expect no label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
