### PR TITLE
security(ci): fix YAML indentation in security-precommit.yml

### DIFF
--- a/.github/workflows/security-precommit.yml
+++ b/.github/workflows/security-precommit.yml
@@ -65,13 +65,13 @@ jobs:
             case "$f" in
               .github/workflows/security-*) continue ;;
               docs/incident-*) continue ;;
-                          .gitleaks.toml) continue ;;
+              .gitleaks.toml) continue ;;
               SECURITY-INCIDENT-*.md) continue ;;
               SECURITY-AUDIT-*.md) continue ;;
               SECURITY-EXCEPTIONS*.md) continue ;;
               SECURITY-POSTMORTEM-*.md) continue ;;
               MALWARE-*.md) continue ;;
-esac
+            esac
             for p in "${PATTERNS[@]}"; do
               if grep -qE "$p" "$f"; then
                 echo "::error file=$f::IoC signature matched: $p"


### PR DESCRIPTION
## Why

The `security-precommit.yml` workflow on master has malformed YAML — `esac` is dedented to column 0 (breaks the `run: |` literal block), and `.gitleaks.toml) continue` (with the case-arm terminator) is over-indented.

Net effect: GitHub can't parse the workflow name, `pull_request` triggers stopped firing, and the `scan-pr` check never posts on PRs. Yesterday `scan-pr` was added as required on the ruleset — which now blocks every PR until this is fixed.

## What

Two indentation corrections in `.github/workflows/security-precommit.yml`:
- `.gitleaks.toml) continue` line — de-indent from 26 spaces → 14 spaces
- `esac` — re-indent from column 0 → 12 spaces (aligned with `case "$f" in`)

## Why this is safe

- No logic change. Indentation only.
- After merge, `pull_request` events fire `scan-pr` correctly (matching bb_app_api's working behavior).
- Logged as §14.3 break-glass entry — `scan-pr` temporarily not required during the merge window to break the catch-22.

## Verification

Compare to bb_app_api's `security-precommit.yml` (lines 65-76) — this brings the file structurally identical.
